### PR TITLE
NASA-10 add test RSV population to Bronchitis Module

### DIFF
--- a/src/main/resources/modules/bronchitis.json
+++ b/src/main/resources/modules/bronchitis.json
@@ -22,8 +22,8 @@
         {
           "condition": {
             "condition_type": "Age",
-            "operator": "<",
-            "quantity": 5,
+            "operator": "<=",
+            "quantity": 6,
             "unit": "years"
           },
           "distributions": [

--- a/src/main/resources/modules/bronchitis.json
+++ b/src/main/resources/modules/bronchitis.json
@@ -23,7 +23,7 @@
           "condition": {
             "condition_type": "Age",
             "operator": "<",
-            "quantity": 18,
+            "quantity": 5,
             "unit": "years"
           },
           "distributions": [
@@ -36,7 +36,15 @@
               ]
             },
             {
-              "distribution": 0.995,
+              "distribution": 0.010,
+              "transition": "RSV_Infection",
+              "remarks": [
+                "6% of children get RSV each year.",
+                "6% / year == ~ .5% per month?"
+              ]
+            },
+            {
+              "distribution": 0.985,
               "transition": "Potential_Infection"
             }
           ]
@@ -67,9 +75,46 @@
           "system": "SNOMED-CT",
           "code": "10509002",
           "display": "Acute bronchitis (disorder)"
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "5505005",
+          "display": "Acute bronchitis (disorder)"
         }
       ],
       "direct_transition": "Bronchitis_Symptom1"
+    },
+    "RSV_Infection" : {
+      "type": "ConditionOnset",
+      "target_encounter": "RSV_Doctor_Visit",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "195739001",
+          "display": "Acute bronchiolitis due to respiratory syncytial virus"
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "55735004",
+          "display": "Respiratory syncytial virus as the cause of diseases classified elsewhere"
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "195727009",
+          "display": "Acute bronchitis due to respiratory syncytial virus"
+        }
+
+      ],
+      "direct_transition": "RSV_Symptom1"
+    },
+    "RSV_Symptom1": {
+      "type": "Symptom",
+      "symptom": "Cough",
+      "range": {
+        "low": 25,
+        "high": 75
+      },
+      "direct_transition": "RSV_Symptoms_Dont_Improve"
     },
     "Bronchitis_Symptom1": {
       "type": "Symptom",
@@ -170,6 +215,43 @@
       },
       "direct_transition": "Doctor_Visit"
     },
+    "RSV_Symptoms_Dont_Improve": {
+      "type": "Delay",
+      "range": {
+        "low": 1,
+        "high": 3,
+        "unit": "days"
+      },
+      "direct_transition": "RSV_Doctor_Visit"
+    },
+    "RSV_Doctor_Visit": {
+      "type": "Encounter",
+      "encounter_class": "inpatient",
+      "reason": "RSV_Infection",
+      "remarks": [
+        "More than 50% of all infants are infected with RSV during the first yr of life",
+        " and by the age of 2 yrs almost all children have been infected [3]. ",
+        " Of these children ∼1–2% will need hospitalisation and ∼10% of these hospitalised children (∼0.1% of all children) will require mechanical ventilation",
+        "for a severe RSV infection during their first yr of life [4] "
+      ],
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "195881003",
+          "display": "Respiratory syncytial virus pneumonia"
+        }
+      ],
+      "distributed_transition": [
+        {
+          "distribution": 0.90,
+          "transition": "RSV_CarePlan_Selector"
+        },
+        {
+          "distribution": 0.10,
+          "transition": "RSV_MechVent"
+        }
+      ]
+    },
     "Doctor_Visit": {
       "type": "Encounter",
       "encounter_class": "ambulatory",
@@ -238,6 +320,40 @@
       },
       "direct_transition": "Bronchitis_CarePlan_Selector"
     },
+    "RSV_MechVent": {
+      "type": "Procedure",
+      "reason": "RSV_Infection",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "40617009",
+          "display": "Artificial respiration (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 1,
+        "high": 4,
+        "unit": "days"
+      },
+      "direct_transition": "Lung_Function_RSV_Test"
+    },
+    "Lung_Function_RSV_Test": {
+      "type": "Procedure",
+      "reason": "RSV_Infection",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "23426006",
+          "display": "Measurement of respiratory function (procedure)"
+        }
+      ],
+      "duration": {
+        "low": 10,
+        "high": 25,
+        "unit": "minutes"
+      },
+      "direct_transition": "RSV_CarePlan_Selector"
+    },
     "Lung_Function_Test": {
       "type": "Procedure",
       "reason": "Bronchitis_Infection",
@@ -254,6 +370,34 @@
         "unit": "minutes"
       },
       "direct_transition": "Bronchitis_CarePlan_Selector"
+    },
+    "RSV_CarePlan_Selector": {
+      "type": "Simple",
+      "conditional_transition": [
+        {
+          "condition": {
+            "condition_type": "And",
+            "conditions": [
+              {
+                "condition_type": "Age",
+                "operator": ">=",
+                "quantity": 18,
+                "unit": "years"
+              },
+              {
+                "condition_type": "Attribute",
+                "attribute": "smoker",
+                "operator": "==",
+                "value": true
+              }
+            ]
+          },
+          "transition": "Rsv_CarePlan"
+        },
+        {
+          "transition": "Rsv_CarePlan"
+        }
+      ]
     },
     "Bronchitis_CarePlan_Selector": {
       "type": "Simple",
@@ -282,6 +426,31 @@
           "transition": "Nonsmoker_CarePlan"
         }
       ]
+    },
+    "Rsv_CarePlan": {
+      "type": "CarePlanStart",
+      "assign_to_attribute": "rsv_careplan",
+      "reason": "RSV_Infection",
+      "codes": [
+        {
+          "system": "SNOMED-CT",
+          "code": "53950000",
+          "display": "Respiratory therapy"
+        }
+      ],
+      "activities": [
+        {
+          "system": "SNOMED-CT",
+          "code": "304510005",
+          "display": "Recommendation to avoid exercise"
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "371605008",
+          "display": "Deep breathing and coughing exercises"
+        }
+      ],
+      "direct_transition": "End_RSV_Doctor_Visit"
     },
     "Smoker_CarePlan": {
       "type": "CarePlanStart",
@@ -406,6 +575,10 @@
       ],
       "direct_transition": "End_Doctor_Visit"
     },
+    "End_RSV_Doctor_Visit": {
+      "type": "EncounterEnd",
+      "direct_transition": "Wait_for_condition_to_resolve2"
+    },
     "End_Doctor_Visit": {
       "type": "EncounterEnd",
       "direct_transition": "Wait_for_condition_to_resolve"
@@ -418,6 +591,28 @@
         "unit": "weeks"
       },
       "direct_transition": "Bronchitis_Subsides"
+    },
+    "Wait_for_condition_to_resolve2": {
+      "type": "Delay",
+      "range": {
+        "low": 1,
+        "high": 3,
+        "unit": "weeks"
+      },
+      "direct_transition": "RSV_Subsides"
+    },
+    "RSV_Subsides": {
+      "type": "ConditionEnd",
+      "condition_onset": "RSV_Infection",
+      "direct_transition": "RSV_Symptom1_Subsides"
+    },
+    "RSV_Symptom1_Subsides": {
+      "type": "Symptom",
+      "symptom": "Cough",
+      "exact": {
+        "quantity": 0
+      },
+      "direct_transition": "Next_Well_Visit_RSV"
     },
     "Bronchitis_Subsides": {
       "type": "ConditionEnd",
@@ -526,9 +721,19 @@
       "wellness": true,
       "direct_transition": "End_Bronchitis_CarePlan"
     },
+    "Next_Well_Visit_RSV": {
+      "type": "Encounter",
+      "wellness": true,
+      "direct_transition": "End_RSV_CarePlan"
+    },
     "End_Bronchitis_CarePlan": {
       "type": "CarePlanEnd",
       "referenced_by_attribute": "bronchitis_careplan",
+      "direct_transition": "End_Wellness_Visit"
+    },
+    "End_RSV_CarePlan": {
+      "type": "CarePlanEnd",
+      "referenced_by_attribute": "rsv_careplan",
       "direct_transition": "End_Wellness_Visit"
     },
     "End_Wellness_Visit": {

--- a/src/main/resources/modules/bronchitis.json
+++ b/src/main/resources/modules/bronchitis.json
@@ -36,15 +36,14 @@
               ]
             },
             {
-              "distribution": 0.010,
+              "distribution": 0.50,
               "transition": "RSV_Infection",
               "remarks": [
-                "6% of children get RSV each year.",
-                "6% / year == ~ .5% per month?"
+                "More than 50% of all infants are infected with RSV during the first yr of life"
               ]
             },
             {
-              "distribution": 0.985,
+              "distribution": 0.495,
               "transition": "Potential_Infection"
             }
           ]
@@ -328,6 +327,21 @@
           "system": "SNOMED-CT",
           "code": "40617009",
           "display": "Artificial respiration (procedure)"
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "243141005",
+          "display": "Mechanicallly assisted spontaneous ventilation (procedure)"
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "82433009",
+          "display": "Continuous negative pressure ventilation (procedure)"
+        },
+        {
+          "system": "SNOMED-CT",
+          "code": "47545007",
+          "display": "Continuous positive pressure ventilation (procedure)"
         }
       ],
       "duration": {
@@ -381,14 +395,8 @@
               {
                 "condition_type": "Age",
                 "operator": ">=",
-                "quantity": 18,
+                "quantity": 2,
                 "unit": "years"
-              },
-              {
-                "condition_type": "Attribute",
-                "attribute": "smoker",
-                "operator": "==",
-                "value": true
               }
             ]
           },


### PR DESCRIPTION
Adding test RSV population data to the Bronchitis Module to simulate Bronchitis among ICU, MV encounters, diagnoses and procedures.

Attached visualization of the new RSV population (left side of diagram)

![bronchitis](https://user-images.githubusercontent.com/44690064/203102437-a6d13213-3290-46cc-953f-dafa9cd71554.png)
